### PR TITLE
Switch to OCaml 4.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,18 +36,11 @@ workflows:
             branches:
               only:
                 - master
-                - mjambon
 
     jobs:
       - build:
-          # Use the CircleCI context that holds our DockerHub login
-          # credentials and exposes them as environment variables
-          # DOCKERHUB_USER and DOCKERHUB_PASS.
-          context: dockerhub
-
           # Run only on these branches (each pushing different images)
           filters:
             branches:
               only:
                 - master
-                - mjambon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
 
     jobs:
       - build:
-          # Run only on these branches (each pushing different images)
+          # Run only on the main branch.
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ workflows:
     # Rebuild periodically rather than based on git changes.
     triggers:
       - schedule:
-          # Run at 10:00 every Wednesday, UTC.
-          cron: "0 10 * * 3"
+          # Run at 07:00 every Wednesday, UTC.
+          cron: "0 07 * * 3"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ workflows:
     # Rebuild periodically rather than based on git changes.
     triggers:
       - schedule:
-          # Run at 11:00 every Wednesday, UTC.
-          cron: "0 11 * * 3"
+          # Run at 07:00 every Thursday, UTC.
+          cron: "0 07 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ workflows:
     # Rebuild periodically rather than based on git changes.
     triggers:
       - schedule:
-          # Run at 07:00 every Wednesday, UTC.
-          cron: "0 07 * * 3"
+          # Run at 11:00 every Wednesday, UTC.
+          cron: "0 11 * * 3"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ workflows:
 
     jobs:
       - build-and-push:
-          # Use the CircleCI context that holds our DockerHub login
-          # credentials and exposes them as environment variables
-          # DOCKERHUB_USER and DOCKERHUB_PASS.
-          context: dockerhub
-
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,31 @@ jobs:
           name: Push
           command: make push
 
+#
+# Build and push a docker image for each change on the main branch and
+# weekly.
+#
+# This occurs after merging a PR or after pushing directly to the main
+# branch. We also build an image every week to keep things fresh since
+# it updates the list of available opam packages and installs the
+# latest version of unpinned packages.
+#
+# Images get tagged with a date like '2021-04-08'. If multiple images
+# get built on the same day, they will overwrite each other, which is
+# fine.
+#
 workflows:
   version: 2
-  build:
+  build-on-master-push:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - master
+                - main
+
+  build-weekly:
     # Rebuild periodically rather than based on git changes.
     triggers:
       - schedule:
@@ -36,6 +58,7 @@ workflows:
             branches:
               only:
                 - master
+                - main
 
     jobs:
       - build:
@@ -44,3 +67,4 @@ workflows:
             branches:
               only:
                 - master
+                - main

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+### Security
+
+- [ ] Change has security implications (if so, ping the security team)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 ifndef SELECTED_CONFIGS
   # The list of configuration files, one per image that you want to build
   # when running 'make' and 'make push'.
-  SELECTED_CONFIGS = configs/alpine.sh
+  SELECTED_CONFIGS = \
+    configs/alpine.sh \
+    configs/ubuntu.sh
 endif
 export SELECTED_CONFIGS
 

--- a/common-config.sh
+++ b/common-config.sh
@@ -48,7 +48,7 @@ opam_packages="
   ounit2
   pcre
   parmap
-  ppxlib.0.20.0
+  ppxlib.0.22.0
   ppx_deriving
   ppx_hash
   ppx_sexp_conv
@@ -60,4 +60,5 @@ opam_packages="
   uutf
   yaml
   yojson
+  visitors.20210608
 "

--- a/common-config.sh
+++ b/common-config.sh
@@ -39,7 +39,7 @@ opam_packages="
   junit_alcotest
   lsp.1.3.0
   merlin
-  menhir
+  menhir.20211128
   num
   ocamlfind
   ocamlformat.0.21.0

--- a/common-config.sh
+++ b/common-config.sh
@@ -2,7 +2,6 @@
 
 # Extra packages to be installed by the native package manager.
 #
-# pfff needs perl.
 # tree-sitter needs pkg-config, npm/node, python (for node-gyp).
 
 # Alpine
@@ -10,7 +9,6 @@ extra_apk_packages="
   nodejs
   npm
   pcre-dev
-  perl
   python3
 "
 
@@ -19,7 +17,6 @@ extra_deb_packages="
   libpcre3-dev
   nodejs
   npm
-  perl
   pkg-config
   python3
 "
@@ -31,7 +28,7 @@ opam_packages="
   atdgen
   bloomf
   cmdliner
-  conf-perl
+  comby.1.4.0
   conf-pkg-config
   dune
   dune-glob

--- a/common-config.sh
+++ b/common-config.sh
@@ -1,0 +1,27 @@
+# To be included in configs/*.sh
+
+# The collection of opam packages we want to install. Go wild.
+opam_packages="
+  alcotest
+  atdgen
+  cmdliner
+  conf-perl
+  conf-pkg-config
+  dune
+  dune-glob
+  grain_dypgen
+  json-wheel
+  menhir
+  num
+  ocamlfind
+  ocamlgraph
+  parmap
+  ppx_deriving
+  ppx_sexp_conv
+  sexplib
+  tsort
+  utop
+  uucp
+  uutf
+  yaml
+"

--- a/common-config.sh
+++ b/common-config.sh
@@ -35,8 +35,8 @@ opam_packages="
   conf-pkg-config
   dune
   dune-glob
-  easy_logging
-  easy_logging_yojson
+  easy_logging.0.8.1
+  easy_logging_yojson.0.8.1
   grain_dypgen
   lsp.1.1.0
   menhir

--- a/common-config.sh
+++ b/common-config.sh
@@ -35,17 +35,18 @@ opam_packages="
   easy_logging.0.8.1
   easy_logging_yojson.0.8.1
   grain_dypgen
-  lsp.1.1.0
+  lsp.1.3.0
+  merlin
   menhir
   num
   ocamlfind
-  ocamlformat.0.15.0
+  ocamlformat.0.16.0
   ocamlgraph
   ocp-indent
   ounit2
   pcre
   parmap
-  ppxlib.0.15.0
+  ppxlib.0.20.0
   ppx_deriving
   ppx_hash
   ppx_sexp_conv

--- a/common-config.sh
+++ b/common-config.sh
@@ -35,6 +35,7 @@ opam_packages="
   conf-pkg-config
   dune
   dune-glob
+  easy_logging
   easy_logging_yojson
   grain_dypgen
   lsp
@@ -44,8 +45,10 @@ opam_packages="
   ocamlgraph
   ocp-indent
   ounit2
+  lsp.1.1.0
   pcre
   parmap
+  ppxlib.0.15.0
   ppx_deriving
   ppx_hash
   ppx_sexp_conv

--- a/common-config.sh
+++ b/common-config.sh
@@ -39,6 +39,7 @@ opam_packages="
   num
   ocamlfind
   ocamlgraph
+  ocp-indent
   ounit2
   parmap
   ppx_deriving

--- a/common-config.sh
+++ b/common-config.sh
@@ -39,7 +39,7 @@ opam_packages="
   menhir
   num
   ocamlfind
-  ocamlformat
+  ocamlformat.0.15.0
   ocamlgraph
   ocp-indent
   ounit2

--- a/common-config.sh
+++ b/common-config.sh
@@ -43,6 +43,7 @@ opam_packages="
   ounit2
   parmap
   ppx_deriving
+  ppx_hash
   ppx_sexp_conv
   re
   sexplib

--- a/common-config.sh
+++ b/common-config.sh
@@ -25,25 +25,29 @@ extra_deb_packages="
 # The collection of opam packages we want to install. Go wild.
 opam_packages="
   alcotest
+  ansiterminal
   atdgen
   cmdliner
   conf-perl
   conf-pkg-config
   dune
   dune-glob
+  easy_logging_yojson
   grain_dypgen
-  json-wheel
   menhir
   num
   ocamlfind
   ocamlgraph
+  ounit2
   parmap
   ppx_deriving
   ppx_sexp_conv
+  re
   sexplib
   tsort
   utop
   uucp
   uutf
   yaml
+  yojson
 "

--- a/common-config.sh
+++ b/common-config.sh
@@ -41,7 +41,7 @@ opam_packages="
   menhir
   num
   ocamlfind
-  ocamlformat.0.16.0
+  ocamlformat.0.21.0
   ocamlgraph
   ocp-indent
   ounit2

--- a/common-config.sh
+++ b/common-config.sh
@@ -38,14 +38,13 @@ opam_packages="
   easy_logging
   easy_logging_yojson
   grain_dypgen
-  lsp
+  lsp.1.1.0
   menhir
   num
   ocamlfind
   ocamlgraph
   ocp-indent
   ounit2
-  lsp.1.1.0
   pcre
   parmap
   ppxlib.0.15.0

--- a/common-config.sh
+++ b/common-config.sh
@@ -28,7 +28,7 @@ opam_packages="
   atdgen
   bloomf
   cmdliner
-  comby.1.4.0
+  comby-kernel.1.4.1
   conf-pkg-config
   dune
   dune-glob

--- a/common-config.sh
+++ b/common-config.sh
@@ -26,6 +26,7 @@ opam_packages="
   alcotest
   ansiterminal
   atdgen
+  atdpy
   bloomf
   cmdliner
   comby-kernel.1.4.1

--- a/common-config.sh
+++ b/common-config.sh
@@ -9,12 +9,14 @@
 extra_apk_packages="
   nodejs
   npm
+  pcre-dev
   perl
   python3
 "
 
 # Ubuntu
 extra_deb_packages="
+  libpcre3-dev
   nodejs
   npm
   perl
@@ -27,6 +29,7 @@ opam_packages="
   alcotest
   ansiterminal
   atdgen
+  bloomf
   cmdliner
   conf-perl
   conf-pkg-config
@@ -41,6 +44,7 @@ opam_packages="
   ocamlgraph
   ocp-indent
   ounit2
+  pcre
   parmap
   ppx_deriving
   ppx_hash

--- a/common-config.sh
+++ b/common-config.sh
@@ -39,6 +39,7 @@ opam_packages="
   menhir
   num
   ocamlfind
+  ocamlformat
   ocamlgraph
   ocp-indent
   ounit2

--- a/common-config.sh
+++ b/common-config.sh
@@ -34,6 +34,7 @@ opam_packages="
   dune-glob
   easy_logging_yojson
   grain_dypgen
+  lsp
   menhir
   num
   ocamlfind

--- a/common-config.sh
+++ b/common-config.sh
@@ -35,6 +35,7 @@ opam_packages="
   easy_logging.0.8.1
   easy_logging_yojson.0.8.1
   grain_dypgen
+  junit_alcotest
   lsp.1.3.0
   merlin
   menhir

--- a/common-config.sh
+++ b/common-config.sh
@@ -1,5 +1,27 @@
 # To be included in configs/*.sh
 
+# Extra packages to be installed by the native package manager.
+#
+# pfff needs perl.
+# tree-sitter needs pkg-config, npm/node, python (for node-gyp).
+
+# Alpine
+extra_apk_packages="
+  nodejs
+  npm
+  perl
+  python3
+"
+
+# Ubuntu
+extra_deb_packages="
+  nodejs
+  npm
+  perl
+  pkg-config
+  python3
+"
+
 # The collection of opam packages we want to install. Go wild.
 opam_packages="
   alcotest

--- a/config.sh
+++ b/config.sh
@@ -1,1 +1,0 @@
-configs/alpine.sh

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,1 @@
+configs/alpine.sh

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -28,7 +28,7 @@ extra_packages="$extra_apk_packages"
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
 
-opam_switch="4.12.0"
+opam_switch="4.14.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -17,6 +17,7 @@ from="alpine:3.12.0"
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
 docker_url="returntocorp/ocaml:alpine"
+extra_docker_urls=("$docker_url-$date")
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -16,7 +16,7 @@ from="alpine:3.12.0"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
-docker_url="mjambon/r2c-ocaml:alpine"
+docker_url="returntocorp/ocaml:alpine"
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -28,7 +28,7 @@ extra_packages="$extra_apk_packages"
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
 
-opam_switch="4.10.2+flambda"
+opam_switch="4.12.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -22,8 +22,4 @@ user="user"
 extra_packages="
 "
 
-# The collection of opam packages we want to install. Go wild.
-opam_packages="
-  dune
-  utop
-"
+. ./common-config.sh

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -3,6 +3,8 @@
 # for pushing it to a docker registry.
 #
 
+. ./common-config.sh
+
 # The OS family. Determines which collection of install scripts to use.
 # Currently, choices are 'alpine' or 'ubuntu'.
 os="alpine"
@@ -19,9 +21,4 @@ docker_url="mjambon/r2c-ocaml:alpine"
 user="user"
 
 # Extra packages to be installed by the native package manager.
-extra_packages="
-  perl
-  python3
-"
-
-. ./common-config.sh
+extra_packages="$extra_apk_packages"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -28,7 +28,7 @@ extra_packages="$extra_apk_packages"
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
 
-opam_switch="4.10.0+flambda"
+opam_switch="4.10.2+flambda"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -13,13 +13,15 @@ from="alpine:3.12.0"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
-docker_url="mjambon/ocaml:alpine"
+docker_url="mjambon/r2c-ocaml:alpine"
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"
 
 # Extra packages to be installed by the native package manager.
 extra_packages="
+  perl
+  python3
 "
 
 . ./common-config.sh

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -27,7 +27,7 @@ extra_packages="$extra_deb_packages"
 
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
-opam_switch="4.12.0"
+opam_switch="4.14.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -27,7 +27,7 @@ extra_packages="$extra_deb_packages"
 
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
-opam_switch="4.10.0+flambda"
+opam_switch="4.10.2+flambda"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -3,6 +3,8 @@
 # for pushing it to a docker registry.
 #
 
+. ./common-config.sh
+
 # The OS family. Determines which collection of install scripts to use.
 # Currently, choices are 'alpine' or 'ubuntu'.
 os="ubuntu"
@@ -19,10 +21,4 @@ docker_url="mjambon/r2c-ocaml:ubuntu"
 user="user"
 
 # Extra packages to be installed by the native package manager.
-extra_packages="
-  perl
-  pkg-config
-  python3
-"
-
-. ./common-config.sh
+extra_packages="$extra_deb_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -12,7 +12,7 @@ os="ubuntu"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="ubuntu"
+from="ubuntu:21.10"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -13,13 +13,16 @@ from="ubuntu"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
-docker_url="mjambon/ocaml:ubuntu"
+docker_url="mjambon/r2c-ocaml:ubuntu"
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"
 
 # Extra packages to be installed by the native package manager.
 extra_packages="
+  perl
+  pkg-config
+  python3
 "
 
 . ./common-config.sh

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -27,7 +27,7 @@ extra_packages="$extra_deb_packages"
 
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
-opam_switch="4.10.2+flambda"
+opam_switch="4.12.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -22,8 +22,4 @@ user="user"
 extra_packages="
 "
 
-# The collection of opam packages we want to install. Go wild.
-opam_packages="
-  dune
-  utop
-"
+. ./common-config.sh

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -17,6 +17,7 @@ from="ubuntu"
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
 docker_url="returntocorp/ocaml:ubuntu"
+extra_docker_urls=("$docker_url-$date")
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -16,7 +16,7 @@ from="ubuntu"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.
-docker_url="mjambon/r2c-ocaml:ubuntu"
+docker_url="returntocorp/ocaml:ubuntu"
 
 # User to create and use. If it already exists, we'll try to use it.
 user="user"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -28,7 +28,4 @@ extra_packages="$extra_deb_packages"
 opam_switch="4.10.0+flambda"
 
 # The collection of opam packages we want to install. Go wild.
-opam_packages="
-  dune
-  utop
-"
+opam_packages="$opam_packages"

--- a/src/os/alpine/setup
+++ b/src/os/alpine/setup
@@ -30,6 +30,7 @@ packages="
   opam
   openssl
   patch
+  py-pip
   rsync
   sudo
   tar
@@ -38,6 +39,9 @@ packages="
 "
 
 apk add $packages
+
+# no apk package for this one
+pip3 install --ignore-installed pre-commit
 
 git config --global user.email "docker@example.com"
 git config --global user.name "Docker"

--- a/src/os/ubuntu/setup
+++ b/src/os/ubuntu/setup
@@ -19,6 +19,7 @@ packages="
   libx11-dev
   nano
   opam
+  python3-pip
   rsync
   sudo
   unzip
@@ -26,6 +27,9 @@ packages="
 "
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
+
+# no deb package for this one
+pip3 install pre-commit
 
 git config --global user.email "docker@example.com"
 git config --global user.name "Docker"


### PR DESCRIPTION
Probably same notes about #5 apply as in #9, but that's more complicated.
(That being said, this isn't urgent, so maybe it would be worth taking
the time to figure it out.)
    
Mainly upgrading for their garbage collection improvements:
> 4.14.0
> Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20% in GC-heavy programs.
    
(from https://ocaml.org/releases)
    
Additionally, we may want to use `Unix.realpath` instead of `Common.fullpath`
if we find that the latter has limitations, but so far it's been fine